### PR TITLE
Adding steps component

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ List of available components.
 | [Menu](https://daisyui.com/components/menu)               | ✅     | ✅        |
 | [Navbar](https://daisyui.com/components/navbar)           | ✅     | ✅        |
 | [Pagination](https://daisyui.com/components/pagination)   | ✅     | ✅        |
-| [Steps](https://daisyui.com/components/steps)             | ❌     | ❌        |
+| [Steps](https://daisyui.com/components/steps)             | ✅     | ❌        |
 | [Tabs](https://daisyui.com/components/tab)                | ✅     | ❌        |
 
 ### Feedback

--- a/lib/daisy_ui_components/steps.ex
+++ b/lib/daisy_ui_components/steps.ex
@@ -41,14 +41,8 @@ defmodule DaisyUIComponents.Steps do
 
   attr :class, :any, default: nil
   attr :content, :string, default: nil
-  attr :neutral, :boolean, default: false
-  attr :primary, :boolean, default: false
-  attr :secondary, :boolean, default: false
-  attr :accent, :boolean, default: false
-  attr :info, :boolean, default: false
-  attr :success, :boolean, default: false
-  attr :warning, :boolean, default: false
-  attr :error, :boolean, default: false
+  attr :color, :string, values: colors() ++ ["neutral"]
+
   attr :rest, :global
 
   slot :inner_block
@@ -78,15 +72,18 @@ defmodule DaisyUIComponents.Steps do
   defp step_classes(assigns) do
     classes([
       "step",
-      maybe_add_class(assigns[:neutral], "step-neutral"),
-      maybe_add_class(assigns[:primary], "step-primary"),
-      maybe_add_class(assigns[:secondary], "step-secondary"),
-      maybe_add_class(assigns[:accent], "step-accent"),
-      maybe_add_class(assigns[:info], "step-info"),
-      maybe_add_class(assigns[:success], "step-success"),
-      maybe_add_class(assigns[:warning], "step-warning"),
-      maybe_add_class(assigns[:error], "step-error"),
+      step_color(assigns[:color]),
       assigns.class
     ])
   end
+
+  defp step_color("neutral"), do: "step-neutral"
+  defp step_color("primary"), do: "step-primary"
+  defp step_color("secondary"), do: "step-secondary"
+  defp step_color("accent"), do: "step-accent"
+  defp step_color("info"), do: "step-info"
+  defp step_color("success"), do: "step-success"
+  defp step_color("warning"), do: "step-warning"
+  defp step_color("error"), do: "step-error"
+  defp step_color(_), do: nil
 end

--- a/lib/daisy_ui_components/steps.ex
+++ b/lib/daisy_ui_components/steps.ex
@@ -40,6 +40,7 @@ defmodule DaisyUIComponents.Steps do
   end
 
   attr :class, :any, default: nil
+  attr :icon, :string, default: nil
   attr :content, :string, default: nil
   attr :color, :string, values: colors() ++ ["neutral"]
 
@@ -53,6 +54,7 @@ defmodule DaisyUIComponents.Steps do
 
     ~H"""
     <li data-content={@content} class={@class} {@rest}>
+      <span :if={@icon} class="step-icon">{@icon}</span>
       {render_slot(@inner_block)}
     </li>
     """

--- a/lib/daisy_ui_components/steps.ex
+++ b/lib/daisy_ui_components/steps.ex
@@ -21,6 +21,11 @@ defmodule DaisyUIComponents.Steps do
 
   use DaisyUIComponents, :component
 
+  @colors ~w(neutral) ++ colors()
+
+  @doc false
+  def step_colors, do: @colors
+
   attr :class, :any, default: nil
   attr :vertical, :boolean, default: false
   attr :horizontal, :boolean, default: false

--- a/lib/daisy_ui_components/steps.ex
+++ b/lib/daisy_ui_components/steps.ex
@@ -1,0 +1,92 @@
+defmodule DaisyUIComponents.Steps do
+  @moduledoc """
+  Steps component used to display a sequence of steps in a process.
+
+  ## Basic Example:
+      <.steps>
+        <.step class="step-primary">Register</.step>
+        <.step class="step-primary">Choose plan</.step>
+        <.step>Purchase</.step>
+        <.step>Receive Product</.step>
+      </.steps>
+
+  ## Renders:
+      <ul class="steps">
+        <li class="step step-primary">Register</li>
+        <li class="step step-primary">Choose plan</li>
+        <li class="step">Purchase</li>
+        <li class="step">Receive Product</li>
+      </ul>
+  """
+
+  use DaisyUIComponents, :component
+
+  attr :class, :any, default: nil
+  attr :vertical, :boolean, default: false
+  attr :horizontal, :boolean, default: false
+  attr :rest, :global
+
+  slot :inner_block
+
+  def steps(assigns) do
+    assigns =
+      assign(assigns, :class, steps_classes(assigns))
+
+    ~H"""
+    <ul class={@class} {@rest}>
+      {render_slot(@inner_block)}
+    </ul>
+    """
+  end
+
+  attr :class, :any, default: nil
+  attr :content, :string, default: nil
+  attr :neutral, :boolean, default: false
+  attr :primary, :boolean, default: false
+  attr :secondary, :boolean, default: false
+  attr :accent, :boolean, default: false
+  attr :info, :boolean, default: false
+  attr :success, :boolean, default: false
+  attr :warning, :boolean, default: false
+  attr :error, :boolean, default: false
+  attr :rest, :global
+
+  slot :inner_block
+
+  def step(assigns) do
+    assigns =
+      assign(assigns, :class, step_classes(assigns))
+
+    ~H"""
+    <li data-content={@content} class={@class} {@rest}>
+      {render_slot(@inner_block)}
+    </li>
+    """
+  end
+
+  # Wrapper Classes
+  defp steps_classes(assigns) do
+    classes([
+      "steps",
+      maybe_add_class(assigns[:vertical], "steps-vertical"),
+      maybe_add_class(assigns[:horizontal], "steps-horizontal"),
+      assigns.class
+    ])
+  end
+
+  # Individual Step Classes
+  defp step_classes(assigns) do
+    classes([
+      "step",
+      maybe_add_class(assigns[:neutral], "step-neutral"),
+      maybe_add_class(assigns[:primary], "step-primary"),
+      maybe_add_class(assigns[:secondary], "step-secondary"),
+      maybe_add_class(assigns[:accent], "step-accent"),
+      maybe_add_class(assigns[:info], "step-info"),
+      maybe_add_class(assigns[:success], "step-success"),
+      maybe_add_class(assigns[:warning], "step-warning"),
+      maybe_add_class(assigns[:error], "step-error"),
+      assigns.class
+    ])
+  end
+end

--- a/test/daisy_ui_components/steps_test.exs
+++ b/test/daisy_ui_components/steps_test.exs
@@ -12,8 +12,8 @@ defmodule DaisyUIComponents.StepsTest do
       component =
         ~H"""
         <.steps>
-          <.step primary>Register</.step>
-          <.step primary>Choose plan</.step>
+          <.step color="primary">Register</.step>
+          <.step color="primary">Choose plan</.step>
           <.step>Purchase</.step>
           <.step>Receive Product</.step>
         </.steps>
@@ -38,8 +38,8 @@ defmodule DaisyUIComponents.StepsTest do
       component =
         ~H"""
         <.steps vertical>
-          <.step primary>Register</.step>
-          <.step primary>Choose plan</.step>
+          <.step color="primary">Register</.step>
+          <.step color="primary">Choose plan</.step>
           <.step>Purchase</.step>
           <.step>Receive Product</.step>
         </.steps>
@@ -64,8 +64,8 @@ defmodule DaisyUIComponents.StepsTest do
       component =
         ~H"""
         <.steps horizontal>
-          <.step primary>Register</.step>
-          <.step primary>Choose plan</.step>
+          <.step color="primary">Register</.step>
+          <.step color="primary">Choose plan</.step>
           <.step>Purchase</.step>
           <.step>Receive Product</.step>
         </.steps>
@@ -90,10 +90,10 @@ defmodule DaisyUIComponents.StepsTest do
       component =
         ~H"""
         <.steps>
-          <.step neutral>
+          <.step color="neutral">
             <span class="step-icon">😕</span>Step 1
           </.step>
-          <.step neutral>
+          <.step color="neutral">
             <span class="step-icon">😃</span>Step 2
           </.step>
           <.step>
@@ -126,13 +126,13 @@ defmodule DaisyUIComponents.StepsTest do
       component =
         ~H"""
         <.steps>
-          <.step content="?" neutral>Step 1</.step>
-          <.step content="!" neutral>Step 2</.step>
-          <.step content="✓" neutral>Step 3</.step>
-          <.step content="✕" neutral="true">Step 4</.step>
-          <.step content="★" neutral="true">Step 5</.step>
-          <.step content="" neutral="true">Step 6</.step>
-          <.step content="●" neutral="true">Step 7</.step>
+          <.step content="?" color="neutral">Step 1</.step>
+          <.step content="!" color="neutral">Step 2</.step>
+          <.step content="✓" color="neutral">Step 3</.step>
+          <.step content="✕" color="neutral">Step 4</.step>
+          <.step content="★" color="neutral">Step 5</.step>
+          <.step content="" color="neutral">Step 6</.step>
+          <.step content="●" color="neutral">Step 7</.step>
         </.steps>
         """
 
@@ -158,10 +158,10 @@ defmodule DaisyUIComponents.StepsTest do
       component =
         ~H"""
         <.steps>
-          <.step info>Fly to moon</.step>
-          <.step info>Shrink the moon</.step>
-          <.step info>Grab the moon</.step>
-          <.step error content="?">Sit</.step>
+          <.step color="info">Fly to moon</.step>
+          <.step color="info">Shrink the moon</.step>
+          <.step color="info">Grab the moon</.step>
+          <.step color="error" content="?">Sit</.step>
         </.steps>
         """
 
@@ -184,13 +184,13 @@ defmodule DaisyUIComponents.StepsTest do
       component =
         ~H"""
         <.steps>
-          <.step neutral>Step 1</.step>
-          <.step primary>Step 2</.step>
-          <.step secondary>Step 3</.step>
-          <.step accent>Step 4</.step>
-          <.step success>Step 5</.step>
-          <.step warning>Step 6</.step>
-          <.step error>Step 7</.step>
+          <.step color="neutral">Step 1</.step>
+          <.step color="primary">Step 2</.step>
+          <.step color="secondary">Step 3</.step>
+          <.step color="accent">Step 4</.step>
+          <.step color="success">Step 5</.step>
+          <.step color="warning">Step 6</.step>
+          <.step color="error">Step 7</.step>
         </.steps>
         """
 

--- a/test/daisy_ui_components/steps_test.exs
+++ b/test/daisy_ui_components/steps_test.exs
@@ -2,7 +2,6 @@ defmodule DaisyUIComponents.StepsTest do
   use DaisyUIComponents.ComponentCase
 
   import Phoenix.Component
-  import Phoenix.LiveViewTest
   import DaisyUIComponents.Steps
 
   describe "steps component" do
@@ -11,229 +10,117 @@ defmodule DaisyUIComponents.StepsTest do
         assigns = %{color: step_color}
 
         ~H"""
-        <.step color={@color}>My Step</.step>
-        """
-        |> parse_component()
-        |> assert_component("li")
-        |> assert_class("step step-#{step_color}")
-        |> assert_text("My Step")
-      end
-    end
-
-    test "basic steps" do
-      assigns = %{}
-
-      component =
-        ~H"""
         <.steps>
-          <.step color="primary">Register</.step>
-          <.step color="primary">Choose plan</.step>
-          <.step>Purchase</.step>
-          <.step>Receive Product</.step>
+          <.step color={@color}>My Step</.step>
         </.steps>
         """
-
-      expected_component =
-        ~H"""
-        <ul class="steps">
-          <li class="step step-primary">Register</li>
-          <li class="step step-primary">Choose plan</li>
-          <li class="step">Purchase</li>
-          <li class="step">Receive Product</li>
-        </ul>
-        """
-
-      assert_components(component, expected_component)
+        |> parse_component()
+        |> assert_component("ul")
+        |> assert_class("steps")
+        |> assert_children("li", fn step ->
+          step
+          |> assert_class("step step-#{step_color}")
+          |> assert_text("My Step")
+        end)
+      end
     end
 
     test "vertical steps" do
       assigns = %{}
 
-      component =
-        ~H"""
-        <.steps vertical>
-          <.step color="primary">Register</.step>
-          <.step color="primary">Choose plan</.step>
-          <.step>Purchase</.step>
-          <.step>Receive Product</.step>
-        </.steps>
-        """
-
-      expected_component =
-        ~H"""
-        <ul class="steps steps-vertical">
-          <li class="step step-primary">Register</li>
-          <li class="step step-primary">Choose plan</li>
-          <li class="step">Purchase</li>
-          <li class="step">Receive Product</li>
-        </ul>
-        """
-
-      assert_components(component, expected_component)
+      ~H"""
+      <.steps vertical>
+        <.step color="primary">Register</.step>
+      </.steps>
+      """
+      |> parse_component()
+      |> assert_component("ul")
+      |> assert_class("steps steps-vertical")
+      |> assert_children("li", fn step ->
+        step
+        |> assert_class("step step-primary")
+        |> assert_text("Register")
+      end)
     end
 
     test "horizontal steps" do
       assigns = %{}
 
-      component =
-        ~H"""
-        <.steps horizontal>
-          <.step color="primary">Register</.step>
-          <.step color="primary">Choose plan</.step>
-          <.step>Purchase</.step>
-          <.step>Receive Product</.step>
-        </.steps>
-        """
-
-      expected_component =
-        ~H"""
-        <ul class="steps steps-horizontal">
-          <li class="step step-primary">Register</li>
-          <li class="step step-primary">Choose plan</li>
-          <li class="step">Purchase</li>
-          <li class="step">Receive Product</li>
-        </ul>
-        """
-
-      assert_components(component, expected_component)
+      ~H"""
+      <.steps horizontal>
+        <.step color="primary">Register</.step>
+      </.steps>
+      """
+      |> parse_component()
+      |> assert_component("ul")
+      |> assert_class("steps steps-horizontal")
+      |> assert_children("li", fn step ->
+        step
+        |> assert_class("step step-primary")
+        |> assert_text("Register")
+      end)
     end
 
     test "steps with icons" do
       assigns = %{}
 
-      component =
-        ~H"""
-        <.steps>
-          <.step color="neutral" icon="😕">
-            Step 1
-          </.step>
-          <.step color="neutral" icon="😃">
-            Step 2
-          </.step>
-          <.step icon="😍">
-            Step 3
-          </.step>
-        </.steps>
-        """
-
-      expected_component =
-        ~H"""
-        <ul class="steps">
-          <li class="step step-neutral">
-            <span class="step-icon">😕</span>Step 1
-          </li>
-          <li class="step step-neutral">
-            <span class="step-icon">😃</span>Step 2
-          </li>
-          <li class="step">
-            <span class="step-icon">😍</span>Step 3
-          </li>
-        </ul>
-        """
-
-      assert_components(component, expected_component)
+      ~H"""
+      <.steps>
+        <.step icon="😕">
+          Step 1
+        </.step>
+      </.steps>
+      """
+      |> parse_component()
+      |> assert_component("ul")
+      |> assert_class("steps")
+      |> assert_children("li", fn step ->
+        step
+        |> assert_class("step")
+        |> assert_children("span", fn icon ->
+          icon
+          |> assert_class("step-icon")
+          |> assert_text("😕")
+        end)
+      end)
     end
 
     test "steps with content" do
       assigns = %{}
 
-      component =
-        ~H"""
-        <.steps>
-          <.step content="?" color="neutral">Step 1</.step>
-          <.step content="!" color="neutral">Step 2</.step>
-          <.step content="✓" color="neutral">Step 3</.step>
-          <.step content="✕" color="neutral">Step 4</.step>
-          <.step content="★" color="neutral">Step 5</.step>
-          <.step content="" color="neutral">Step 6</.step>
-          <.step content="●" color="neutral">Step 7</.step>
-        </.steps>
-        """
-
-      expected_component =
-        ~H"""
-        <ul class="steps">
-          <li data-content="?" class="step step-neutral">Step 1</li>
-          <li data-content="!" class="step step-neutral">Step 2</li>
-          <li data-content="✓" class="step step-neutral">Step 3</li>
-          <li data-content="✕" class="step step-neutral">Step 4</li>
-          <li data-content="★" class="step step-neutral">Step 5</li>
-          <li data-content="" class="step step-neutral">Step 6</li>
-          <li data-content="●" class="step step-neutral">Step 7</li>
-        </ul>
-        """
-
-      assert_components(component, expected_component)
+      ~H"""
+      <.steps>
+        <.step content="★">Step 1</.step>
+      </.steps>
+      """
+      |> parse_component()
+      |> assert_component("ul")
+      |> assert_class("steps")
+      |> assert_children("li", fn step ->
+        step
+        |> assert_class("step")
+        |> assert_attribute("data-content", "★")
+        |> assert_text("Step 1")
+      end)
     end
 
     test "steps with colors and error state" do
       assigns = %{}
 
-      component =
-        ~H"""
-        <.steps>
-          <.step color="info">Fly to moon</.step>
-          <.step color="info">Shrink the moon</.step>
-          <.step color="info">Grab the moon</.step>
-          <.step color="error" content="?">Sit</.step>
-        </.steps>
-        """
-
-      expected_component =
-        ~H"""
-        <ul class="steps">
-          <li class="step step-info">Fly to moon</li>
-          <li class="step step-info">Shrink the moon</li>
-          <li class="step step-info">Grab the moon</li>
-          <li data-content="?" class="step step-error">Sit</li>
-        </ul>
-        """
-
-      assert_components(component, expected_component)
+      ~H"""
+      <.steps>
+        <.step color="error" content="?">Sit</.step>
+      </.steps>
+      """
+      |> parse_component()
+      |> assert_component("ul")
+      |> assert_class("steps")
+      |> assert_children("li", fn step ->
+        step
+        |> assert_class("step step-error")
+        |> assert_attribute("data-content", "?")
+        |> assert_text("Sit")
+      end)
     end
-
-    test "steps with multiple styles" do
-      assigns = %{}
-
-      component =
-        ~H"""
-        <.steps>
-          <.step color="neutral">Step 1</.step>
-          <.step color="primary">Step 2</.step>
-          <.step color="secondary">Step 3</.step>
-          <.step color="accent">Step 4</.step>
-          <.step color="success">Step 5</.step>
-          <.step color="warning">Step 6</.step>
-          <.step color="error">Step 7</.step>
-        </.steps>
-        """
-
-      expected_component =
-        ~H"""
-        <ul class="steps">
-          <li class="step step-neutral">Step 1</li>
-          <li class="step step-primary">Step 2</li>
-          <li class="step step-secondary">Step 3</li>
-          <li class="step step-accent">Step 4</li>
-          <li class="step step-success">Step 5</li>
-          <li class="step step-warning">Step 6</li>
-          <li class="step step-error">Step 7</li>
-        </ul>
-        """
-
-      assert_components(component, expected_component)
-    end
-  end
-
-  defp assert_components(rendered_component, expected_component) do
-    rendered_component_str = rendered_to_string(rendered_component) |> remove_whitespace()
-    expected_component_str = rendered_to_string(expected_component) |> remove_whitespace()
-    assert rendered_component_str == expected_component_str
-  end
-
-  defp remove_whitespace(str) do
-    str
-    |> String.replace(~r/\s+/, "")
-    |> String.trim()
   end
 end

--- a/test/daisy_ui_components/steps_test.exs
+++ b/test/daisy_ui_components/steps_test.exs
@@ -1,0 +1,225 @@
+defmodule DaisyUIComponents.StepsTest do
+  use DaisyUIComponents.ComponentCase
+
+  import Phoenix.Component
+  import Phoenix.LiveViewTest
+  import DaisyUIComponents.Steps
+
+  describe "steps component" do
+    test "basic steps" do
+      assigns = %{}
+
+      component =
+        ~H"""
+        <.steps>
+          <.step primary>Register</.step>
+          <.step primary>Choose plan</.step>
+          <.step>Purchase</.step>
+          <.step>Receive Product</.step>
+        </.steps>
+        """
+
+      expected_component =
+        ~H"""
+        <ul class="steps">
+          <li class="step step-primary">Register</li>
+          <li class="step step-primary">Choose plan</li>
+          <li class="step">Purchase</li>
+          <li class="step">Receive Product</li>
+        </ul>
+        """
+
+      assert_components(component, expected_component)
+    end
+
+    test "vertical steps" do
+      assigns = %{}
+
+      component =
+        ~H"""
+        <.steps vertical>
+          <.step primary>Register</.step>
+          <.step primary>Choose plan</.step>
+          <.step>Purchase</.step>
+          <.step>Receive Product</.step>
+        </.steps>
+        """
+
+      expected_component =
+        ~H"""
+        <ul class="steps steps-vertical">
+          <li class="step step-primary">Register</li>
+          <li class="step step-primary">Choose plan</li>
+          <li class="step">Purchase</li>
+          <li class="step">Receive Product</li>
+        </ul>
+        """
+
+      assert_components(component, expected_component)
+    end
+
+    test "horizontal steps" do
+      assigns = %{}
+
+      component =
+        ~H"""
+        <.steps horizontal>
+          <.step primary>Register</.step>
+          <.step primary>Choose plan</.step>
+          <.step>Purchase</.step>
+          <.step>Receive Product</.step>
+        </.steps>
+        """
+
+      expected_component =
+        ~H"""
+        <ul class="steps steps-horizontal">
+          <li class="step step-primary">Register</li>
+          <li class="step step-primary">Choose plan</li>
+          <li class="step">Purchase</li>
+          <li class="step">Receive Product</li>
+        </ul>
+        """
+
+      assert_components(component, expected_component)
+    end
+
+    test "steps with icons" do
+      assigns = %{}
+
+      component =
+        ~H"""
+        <.steps>
+          <.step neutral>
+            <span class="step-icon">😕</span>Step 1
+          </.step>
+          <.step neutral>
+            <span class="step-icon">😃</span>Step 2
+          </.step>
+          <.step>
+            <span class="step-icon">😍</span>Step 3
+          </.step>
+        </.steps>
+        """
+
+      expected_component =
+        ~H"""
+        <ul class="steps">
+          <li class="step step-neutral">
+            <span class="step-icon">😕</span>Step 1
+          </li>
+          <li class="step step-neutral">
+            <span class="step-icon">😃</span>Step 2
+          </li>
+          <li class="step">
+            <span class="step-icon">😍</span>Step 3
+          </li>
+        </ul>
+        """
+
+      assert_components(component, expected_component)
+    end
+
+    test "steps with content" do
+      assigns = %{}
+
+      component =
+        ~H"""
+        <.steps>
+          <.step content="?" neutral>Step 1</.step>
+          <.step content="!" neutral>Step 2</.step>
+          <.step content="✓" neutral>Step 3</.step>
+          <.step content="✕" neutral="true">Step 4</.step>
+          <.step content="★" neutral="true">Step 5</.step>
+          <.step content="" neutral="true">Step 6</.step>
+          <.step content="●" neutral="true">Step 7</.step>
+        </.steps>
+        """
+
+      expected_component =
+        ~H"""
+        <ul class="steps">
+          <li data-content="?" class="step step-neutral">Step 1</li>
+          <li data-content="!" class="step step-neutral">Step 2</li>
+          <li data-content="✓" class="step step-neutral">Step 3</li>
+          <li data-content="✕" class="step step-neutral">Step 4</li>
+          <li data-content="★" class="step step-neutral">Step 5</li>
+          <li data-content="" class="step step-neutral">Step 6</li>
+          <li data-content="●" class="step step-neutral">Step 7</li>
+        </ul>
+        """
+
+      assert_components(component, expected_component)
+    end
+
+    test "steps with colors and error state" do
+      assigns = %{}
+
+      component =
+        ~H"""
+        <.steps>
+          <.step info>Fly to moon</.step>
+          <.step info>Shrink the moon</.step>
+          <.step info>Grab the moon</.step>
+          <.step error content="?">Sit</.step>
+        </.steps>
+        """
+
+      expected_component =
+        ~H"""
+        <ul class="steps">
+          <li class="step step-info">Fly to moon</li>
+          <li class="step step-info">Shrink the moon</li>
+          <li class="step step-info">Grab the moon</li>
+          <li data-content="?" class="step step-error">Sit</li>
+        </ul>
+        """
+
+      assert_components(component, expected_component)
+    end
+
+    test "steps with multiple styles" do
+      assigns = %{}
+
+      component =
+        ~H"""
+        <.steps>
+          <.step neutral>Step 1</.step>
+          <.step primary>Step 2</.step>
+          <.step secondary>Step 3</.step>
+          <.step accent>Step 4</.step>
+          <.step success>Step 5</.step>
+          <.step warning>Step 6</.step>
+          <.step error>Step 7</.step>
+        </.steps>
+        """
+
+      expected_component =
+        ~H"""
+        <ul class="steps">
+          <li class="step step-neutral">Step 1</li>
+          <li class="step step-primary">Step 2</li>
+          <li class="step step-secondary">Step 3</li>
+          <li class="step step-accent">Step 4</li>
+          <li class="step step-success">Step 5</li>
+          <li class="step step-warning">Step 6</li>
+          <li class="step step-error">Step 7</li>
+        </ul>
+        """
+
+      assert_components(component, expected_component)
+    end
+  end
+
+  defp assert_components(rendered_component, expected_component) do
+    rendered_component_str = rendered_to_string(rendered_component) |> remove_whitespace()
+    expected_component_str = rendered_to_string(expected_component) |> remove_whitespace()
+    assert rendered_component_str == expected_component_str
+  end
+
+  defp remove_whitespace(str) do
+    str
+    |> String.replace(~r/\s+/, "")
+    |> String.trim()
+  end
+end

--- a/test/daisy_ui_components/steps_test.exs
+++ b/test/daisy_ui_components/steps_test.exs
@@ -5,6 +5,8 @@ defmodule DaisyUIComponents.StepsTest do
   import Phoenix.LiveViewTest
   import DaisyUIComponents.Steps
 
+  alias DaisyUIComponents.Utils
+
   describe "steps component" do
     test "basic steps" do
       assigns = %{}
@@ -90,14 +92,14 @@ defmodule DaisyUIComponents.StepsTest do
       component =
         ~H"""
         <.steps>
-          <.step color="neutral">
-            <span class="step-icon">😕</span>Step 1
+          <.step color="neutral" icon="😕">
+            Step 1
           </.step>
-          <.step color="neutral">
-            <span class="step-icon">😃</span>Step 2
+          <.step color="neutral" icon="😃">
+            Step 2
           </.step>
-          <.step>
-            <span class="step-icon">😍</span>Step 3
+          <.step icon="😍">
+            Step 3
           </.step>
         </.steps>
         """

--- a/test/daisy_ui_components/steps_test.exs
+++ b/test/daisy_ui_components/steps_test.exs
@@ -5,9 +5,21 @@ defmodule DaisyUIComponents.StepsTest do
   import Phoenix.LiveViewTest
   import DaisyUIComponents.Steps
 
-  alias DaisyUIComponents.Utils
-
   describe "steps component" do
+    test "expected classes added" do
+      for step_color <- step_colors() do
+        assigns = %{color: step_color}
+
+        ~H"""
+        <.step color={@color}>My Step</.step>
+        """
+        |> parse_component()
+        |> assert_component("li")
+        |> assert_class("step step-#{step_color}")
+        |> assert_text("My Step")
+      end
+    end
+
     test "basic steps" do
       assigns = %{}
 


### PR DESCRIPTION
## Description

Adding [DaisyUI Steps](https://daisyui.com/components/steps/) component.

## Question

I am not sure how to best handle `<span class="step-icon">😍</span>Step 3` block. In this iteration its not handled at all and just rendered as part of `inner_block`. This is the [example](https://daisyui.com/components/steps/#with-custom-content-in-step-icon) of it.

We could add a `title` argument and an `icon` argument that will work the same way as the `content` attribute that adds `data-content`.  If there is a `title` argument, we won't render the `inner_block`, but you could also add an `icon` argument to go along with `title`.