### PR TITLE
Fix card slot definitions

### DIFF
--- a/lib/daisy_ui_components/card.ex
+++ b/lib/daisy_ui_components/card.ex
@@ -43,8 +43,10 @@ defmodule DaisyUIComponents.Card do
 
   slot :card_body do
     attr :class, :any
+  end
 
-    slot :card_actions
+  slot :card_actions do
+    attr :class, :any
   end
 
   slot :inner_block


### PR DESCRIPTION
The card slot definitions has the `card_actions` slot inside the `card_body` slot. Components don't support nested slots and this definition was causing compile warnings like the following.
```
warning: undefined attribute "class" in slot "card_body" for component DaisyUIComponents.Card.card/1
    │
 66 │       <:card_body class="body">
```
This change fixes the slot definitions and the compile warning.