### PR TITLE
Limit globals to progress to value / max

### DIFF
--- a/lib/daisy_ui_components/progress.ex
+++ b/lib/daisy_ui_components/progress.ex
@@ -21,7 +21,7 @@ defmodule DaisyUIComponents.Progress do
   """
   attr :class, :any, default: nil
   attr :color, :string, values: @colors
-  attr :rest, :global
+  attr :rest, :global, include: ~w(value max)
   slot :inner_block
 
   def progress(assigns) do


### PR DESCRIPTION
Should fix this: `warning: undefined attribute "max" for component DaisyUIComponents.Progress.progress/1`