### PR TITLE
Fix <.input type="textarea"> adding multiple `\n` to the value

### DIFF
--- a/lib/daisy_ui_components/form.ex
+++ b/lib/daisy_ui_components/form.ex
@@ -182,16 +182,7 @@ defmodule DaisyUIComponents.Form do
       <.fieldset_label for={@id}>
         {@label}
       </.fieldset_label>
-      <.input
-        id={@id}
-        type="textarea"
-        name={@name}
-        color={@color}
-        class={[@class, "w-full"]}
-        prompt={@prompt}
-        value={Phoenix.HTML.Form.normalize_value(@type, @value)}
-        {@rest}
-      />
+      <.input id={@id} type="textarea" name={@name} color={@color} class={[@class, "w-full"]} prompt={@prompt} value={@value} {@rest} />
       <.error :for={msg <- @errors}>{msg}</.error>
     </.fieldset>
     """

--- a/lib/daisy_ui_components/input.ex
+++ b/lib/daisy_ui_components/input.ex
@@ -127,9 +127,7 @@ defmodule DaisyUIComponents.Input do
       |> assign_new(:value, fn -> nil end)
 
     ~H"""
-    <.textarea id={@id} name={@name} class={@class} color={@color} ghost={@ghost} {@rest}>
-      {Phoenix.HTML.Form.normalize_value(@type, @value)}
-    </.textarea>
+    <.textarea id={@id} name={@name} class={@class} color={@color} ghost={@ghost} {@rest}>{Phoenix.HTML.Form.normalize_value(@type, @value)}</.textarea>
     """
   end
 


### PR DESCRIPTION
- Removes double newlines (`\n\n`) added to textarea values (input.ex)
- Prevents double normalization in form textareas that converts empty values to `\n` (form.ex)