### PR TITLE
Pagination js event

### DIFF
--- a/lib/daisy_ui_components/pagination.ex
+++ b/lib/daisy_ui_components/pagination.ex
@@ -25,7 +25,7 @@ defmodule DaisyUIComponents.Pagination do
   attr :button_class, :string, default: nil
   attr :size, :string, values: sizes()
   attr :target, :string, default: nil
-  attr :page_click_event, :string, default: "page_click"
+  attr :page_click_event, :any, default: "page_click"
   attr :rest, :global
 
   def pagination(assigns) do
@@ -37,7 +37,8 @@ defmodule DaisyUIComponents.Pagination do
         <.button
           class={["join-item", @button_class]}
           size={@size}
-          phx-click={JS.push(@page_click_event, value: %{page: block})}
+          phx-click={@page_click_event}
+          phx-value-page={block}
           phx-target={@target}
           active={block == @page}
           disabled={block == "..."}

--- a/test/daisy_ui_components/pagination_test.exs
+++ b/test/daisy_ui_components/pagination_test.exs
@@ -24,6 +24,19 @@ defmodule DaisyUIComponents.PaginationTest do
     defmodule PageLive do
       use Phoenix.LiveView
       import DaisyUIComponents.Pagination
+      alias Phoenix.LiveView.JS
+
+      def render(%{case: "with_custom_event"} = assigns) do
+        ~H"""
+        <p id="page">Current page: {@page}</p>
+        <.pagination
+          page={@page}
+          page_size={10}
+          total_entries={100}
+          page_click_event={JS.push("page_click", loading: "#page")}
+        />
+        """
+      end
 
       def render(assigns) do
         ~H"""
@@ -32,12 +45,12 @@ defmodule DaisyUIComponents.PaginationTest do
         """
       end
 
-      def mount(_params, _session, socket) do
-        {:ok, assign(socket, :page, 1)}
+      def mount(_params, session, socket) do
+        {:ok, assign(socket, page: 1, case: session["case"])}
       end
 
       def handle_event("page_click", %{"page" => page}, socket) do
-        {:noreply, assign(socket, :page, page)}
+        {:noreply, assign(socket, :page, String.to_integer(page))}
       end
     end
 
@@ -45,6 +58,11 @@ defmodule DaisyUIComponents.PaginationTest do
 
     html =~ "Current page: 1"
     assert render_click(element(view, "button", "2")) =~ "Current page: 2"
+
+    {:ok, view, html} = live_isolated(conn, PageLive, session: %{"case" => "with_custom_event"})
+
+    html =~ "Current page: 1"
+    assert render_click(element(view, "button", "3")) =~ "Current page: 3"
   end
 
   test "calculate_display_btn" do

--- a/test/daisy_ui_components/pagination_test.exs
+++ b/test/daisy_ui_components/pagination_test.exs
@@ -1,22 +1,50 @@
 defmodule DaisyUIComponents.PaginationTest do
-  use ExUnit.Case
+  use DaisyUIComponents.IntegrationCase
+
   import Phoenix.Component
-  import Phoenix.LiveViewTest
 
   import DaisyUIComponents.Pagination
 
   test "pagination" do
     assigns = %{page: 1, page_size: 10, total_entries: 100}
 
-    pagination =
-      rendered_to_string(~H"""
-      <.pagination />
-      """)
+    template = ~H"""
+    <.pagination />
+    """
+
+    pagination = rendered_to_string(template)
 
     assert pagination =~ ~s(<div class="join">)
     assert pagination =~ ~s(<button class="btn join-item")
     assert pagination =~ ~s(<button class="btn btn-active join-item")
     assert pagination =~ ~s(<button class="btn btn-disabled join-item")
+  end
+
+  test "triggers event on page click", %{conn: conn} do
+    defmodule PageLive do
+      use Phoenix.LiveView
+      import DaisyUIComponents.Pagination
+
+      def render(assigns) do
+        ~H"""
+        <p>Current page: {@page}</p>
+        <.pagination page={@page} page_size={10} total_entries={100} />
+        """
+      end
+
+      def mount(_params, _session, socket) do
+        {:ok, assign(socket, :page, 1)}
+      end
+
+      def handle_event("page_click", %{"page" => page}, socket) do
+        {:noreply, assign(socket, :page, page)}
+      end
+    end
+
+    {:ok, view, html} = live_isolated(conn, PageLive)
+
+    html =~ "Current page: 1"
+    assert render_click(element(view, "button", "2")) =~ "Current page: 2"
   end
 
   test "calculate_display_btn" do

--- a/test/support/integration_case.ex
+++ b/test/support/integration_case.ex
@@ -1,0 +1,27 @@
+defmodule DaisyUIComponents.IntegrationCase do
+  use ExUnit.CaseTemplate
+
+  defmodule Endpoint do
+    use Phoenix.Endpoint, otp_app: :daisy_ui_components
+  end
+
+  using do
+    quote do
+      @endpoint DaisyUIComponents.IntegrationCase.Endpoint
+
+      import Phoenix.ConnTest
+      import Phoenix.LiveViewTest
+    end
+  end
+
+  setup do
+    Application.put_env(:daisy_ui_components, Endpoint,
+      live_view: [signing_salt: "aaaaaaaa"],
+      secret_key_base: String.duplicate("a", 64)
+    )
+
+    start_supervised!(Endpoint)
+
+    %{conn: Phoenix.ConnTest.build_conn()}
+  end
+end


### PR DESCRIPTION
Currently, the `pagination` component calls the `JS.push` function directly on the `phx-click` of the page button, which forbids the dev from passing [enhanced push events](https://hexdocs.pm/phoenix_live_view/1.0.17/Phoenix.LiveView.JS.html#module-enhanced-push-events) when clicking on the button.

Allowing custom `JS.push` commands to be passed down to the `pagination` component would allow us to define [custom loading logics](https://fly.io/phoenix-files/js-push-loading-options/#solution) that would improve the user experience, given paginating can be expensive and take some time to load. 