### PR TITLE
Accept `href` in `tab` component

### DIFF
--- a/installer/templates/components/tabs.ex
+++ b/installer/templates/components/tabs.ex
@@ -162,7 +162,7 @@ defmodule <%= if not @dev do @web_namespace <> "." end %>DaisyUIComponents.Tabs 
   attr :name, :string, default: nil
   attr :active, :boolean, default: false
   attr :disabled, :boolean, default: false
-  attr :rest, :global
+  attr :rest, :global, include: ~w(href)
 
   slot :inner_block
 
@@ -309,7 +309,7 @@ defmodule <%= if not @dev do @web_namespace <> "." end %>DaisyUIComponents.Tabs 
 
   attr :title, :string
   attr :class, :any, default: nil
-  attr :rest, :global
+  attr :rest, :global, include: ~w(href)
 
   slot :inner_block
 

--- a/lib/daisy_ui_components/tabs.ex
+++ b/lib/daisy_ui_components/tabs.ex
@@ -162,7 +162,7 @@ defmodule DaisyUIComponents.Tabs do
   attr :name, :string, default: nil
   attr :active, :boolean, default: false
   attr :disabled, :boolean, default: false
-  attr :rest, :global
+  attr :rest, :global, include: ~w(href)
 
   slot :inner_block
 
@@ -309,7 +309,7 @@ defmodule DaisyUIComponents.Tabs do
 
   attr :title, :string
   attr :class, :any, default: nil
-  attr :rest, :global
+  attr :rest, :global, include: ~w(href)
 
   slot :inner_block
 


### PR DESCRIPTION
TIL that global attributes only accept attributes common to all HTML elements (https://github.com/phoenixframework/phoenix_live_view/issues/2292#issuecomment-1287792051) and therefore we must explicitly define `href` for the `tab` component to suppress this warning:

<img width="981" height="115" alt="image" src="https://github.com/user-attachments/assets/d526db89-c170-45e2-840e-a2779e520cd3" />
