### PR TITLE
Add missing `form` attribute for several controls

### DIFF
--- a/installer/templates/components/checkbox.ex
+++ b/installer/templates/components/checkbox.ex
@@ -12,7 +12,7 @@ defmodule <%= if not @dev do @web_namespace <> "." end %>DaisyUIComponents.Check
   attr :value, :any, default: nil
   attr :color, :string, values: colors()
   attr :size, :string, values: sizes()
-  attr :rest, :global, include: ~w(name)
+  attr :rest, :global, include: ~w(form name)
 
   def checkbox(assigns) do
     assigns =

--- a/installer/templates/components/radio.ex
+++ b/installer/templates/components/radio.ex
@@ -12,7 +12,7 @@ defmodule <%= if not @dev do @web_namespace <> "." end %>DaisyUIComponents.Radio
   attr :value, :any, default: nil
   attr :color, :string, values: colors()
   attr :size, :string, values: sizes()
-  attr :rest, :global, include: ~w(name)
+  attr :rest, :global, include: ~w(form name)
 
   def radio(assigns) do
     assigns =

--- a/installer/templates/components/range.ex
+++ b/installer/templates/components/range.ex
@@ -14,7 +14,7 @@ defmodule <%= if not @dev do @web_namespace <> "." end %>DaisyUIComponents.Range
   attr :min, :integer, default: nil
   attr :max, :integer, default: nil
   attr :step, :integer, default: nil
-  attr :rest, :global, include: ~w(name)
+  attr :rest, :global, include: ~w(form name)
 
   def range(assigns) do
     assigns =

--- a/installer/templates/components/select.ex
+++ b/installer/templates/components/select.ex
@@ -14,7 +14,7 @@ defmodule <%= if not @dev do @web_namespace <> "." end %>DaisyUIComponents.Selec
   attr :ghost, :boolean, default: false
   attr :size, :string, values: sizes()
   attr :value, :any, default: nil
-  attr :rest, :global, include: ~w(name value multiple)
+  attr :rest, :global, include: ~w(form name value multiple)
   slot :inner_block
 
   def select(assigns) do

--- a/installer/templates/components/text_input.ex
+++ b/installer/templates/components/text_input.ex
@@ -12,7 +12,7 @@ defmodule <%= if not @dev do @web_namespace <> "." end %>DaisyUIComponents.TextI
   attr :color, :string, values: colors()
   attr :ghost, :boolean, default: false
   attr :size, :string, values: sizes()
-  attr :rest, :global, include: ~w(name value)
+  attr :rest, :global, include: ~w(form name value)
 
   def text_input(assigns) do
     assigns =

--- a/installer/templates/components/textarea.ex
+++ b/installer/templates/components/textarea.ex
@@ -12,7 +12,7 @@ defmodule <%= if not @dev do @web_namespace <> "." end %>DaisyUIComponents.Texta
   attr :color, :string, values: colors()
   attr :ghost, :boolean, default: false
   attr :size, :string, values: sizes()
-  attr :rest, :global, include: ~w(name rows cols)
+  attr :rest, :global, include: ~w(form name rows cols)
   slot :inner_block
 
   def textarea(assigns) do

--- a/installer/templates/components/toggle.ex
+++ b/installer/templates/components/toggle.ex
@@ -12,7 +12,7 @@ defmodule <%= if not @dev do @web_namespace <> "." end %>DaisyUIComponents.Toggl
   attr :value, :any, default: nil
   attr :color, :string, values: colors()
   attr :size, :string, values: sizes()
-  attr :rest, :global, include: ~w(name)
+  attr :rest, :global, include: ~w(form name)
 
   def toggle(assigns) do
     assigns =

--- a/lib/daisy_ui_components/checkbox.ex
+++ b/lib/daisy_ui_components/checkbox.ex
@@ -12,7 +12,7 @@ defmodule DaisyUIComponents.Checkbox do
   attr :value, :any, default: nil
   attr :color, :string, values: colors()
   attr :size, :string, values: sizes()
-  attr :rest, :global, include: ~w(name)
+  attr :rest, :global, include: ~w(form name)
 
   def checkbox(assigns) do
     assigns =

--- a/lib/daisy_ui_components/radio.ex
+++ b/lib/daisy_ui_components/radio.ex
@@ -12,7 +12,7 @@ defmodule DaisyUIComponents.Radio do
   attr :value, :any, default: nil
   attr :color, :string, values: colors()
   attr :size, :string, values: sizes()
-  attr :rest, :global, include: ~w(name)
+  attr :rest, :global, include: ~w(form name)
 
   def radio(assigns) do
     assigns =

--- a/lib/daisy_ui_components/range.ex
+++ b/lib/daisy_ui_components/range.ex
@@ -14,7 +14,7 @@ defmodule DaisyUIComponents.Range do
   attr :min, :integer, default: nil
   attr :max, :integer, default: nil
   attr :step, :integer, default: nil
-  attr :rest, :global, include: ~w(name)
+  attr :rest, :global, include: ~w(form name)
 
   def range(assigns) do
     assigns =

--- a/lib/daisy_ui_components/select.ex
+++ b/lib/daisy_ui_components/select.ex
@@ -14,7 +14,7 @@ defmodule DaisyUIComponents.Select do
   attr :ghost, :boolean, default: false
   attr :size, :string, values: sizes()
   attr :value, :any, default: nil
-  attr :rest, :global, include: ~w(name value multiple)
+  attr :rest, :global, include: ~w(form name value multiple)
   slot :inner_block
 
   def select(assigns) do

--- a/lib/daisy_ui_components/text_input.ex
+++ b/lib/daisy_ui_components/text_input.ex
@@ -12,7 +12,7 @@ defmodule DaisyUIComponents.TextInput do
   attr :color, :string, values: colors()
   attr :ghost, :boolean, default: false
   attr :size, :string, values: sizes()
-  attr :rest, :global, include: ~w(name value)
+  attr :rest, :global, include: ~w(form name value)
 
   def text_input(assigns) do
     assigns =

--- a/lib/daisy_ui_components/textarea.ex
+++ b/lib/daisy_ui_components/textarea.ex
@@ -12,7 +12,7 @@ defmodule DaisyUIComponents.Textarea do
   attr :color, :string, values: colors()
   attr :ghost, :boolean, default: false
   attr :size, :string, values: sizes()
-  attr :rest, :global, include: ~w(name rows cols)
+  attr :rest, :global, include: ~w(form name rows cols)
   slot :inner_block
 
   def textarea(assigns) do

--- a/lib/daisy_ui_components/toggle.ex
+++ b/lib/daisy_ui_components/toggle.ex
@@ -12,7 +12,7 @@ defmodule DaisyUIComponents.Toggle do
   attr :value, :any, default: nil
   attr :color, :string, values: colors()
   attr :size, :string, values: sizes()
-  attr :rest, :global, include: ~w(name)
+  attr :rest, :global, include: ~w(form name)
 
   def toggle(assigns) do
     assigns =


### PR DESCRIPTION
Fixes warnings of the following kind when using a control which is not nested in a `<form>` tag, and which therefore needs to use the `form` attribute:
```
undefined attribute "form" for component DaisyUIComponents.Checkbox.checkbox/1
```