### PR TITLE
Fixing the table component cyclical dependency

### DIFF
--- a/installer/lib/daisy/single.ex
+++ b/installer/lib/daisy/single.ex
@@ -349,11 +349,6 @@ defmodule Daisy.New.Single do
 
   defp add_deps(set, "swap"), do: add_dep_component(set, "icon")
 
-  defp add_deps(set, "table") do
-    set
-    |> add_dep_component("table")
-  end
-
   defp add_deps(set, _), do: set
 
   defp add_dep_component(set, component) do


### PR DESCRIPTION
It was causing an infinite loop, because `add_dep_component` calls `add_deps` passing the same as its arguments.

Fixes #126 