### PR TITLE
Add and refactor table attributes and related tests

### DIFF
--- a/installer/templates/components/table.ex
+++ b/installer/templates/components/table.ex
@@ -223,7 +223,7 @@ defmodule <%= if not @dev do @web_namespace <> "." end %>DaisyUIComponents.Table
 
   attr :class, :any, default: nil
   attr :collapse_breakpoint, :string, values: sizes()
-  attr :rest, :global
+  attr :rest, :global, include: ~w(colspan headers rowspan)
   slot :inner_block
 
   def td(assigns) do
@@ -260,7 +260,7 @@ defmodule <%= if not @dev do @web_namespace <> "." end %>DaisyUIComponents.Table
     default: "sort",
     doc: "the event name for phx-click on header columns for sorting"
 
-  attr :rest, :global
+  attr :rest, :global, include: ~w(abbr colspan headers rowspan scope)
   slot :inner_block
 
   def th(assigns) do

--- a/lib/daisy_ui_components/table.ex
+++ b/lib/daisy_ui_components/table.ex
@@ -95,7 +95,7 @@ defmodule DaisyUIComponents.Table do
 
   attr :zebra, :boolean, default: false
   attr :size, :string, values: sizes()
-  attr :rest, :global, include: ~w(align bgcolor border cellpadding cellspacing frame rules summary width)
+  attr :rest, :global
   slot :inner_block
 
   def table(%{rows: _rows} = assigns) do
@@ -199,7 +199,7 @@ defmodule DaisyUIComponents.Table do
   attr :class, :any, default: nil
   attr :active, :boolean, default: false
   attr :hover, :boolean, default: false
-  attr :rest, :global, include: ~w(align bgcolor char charoff valign)
+  attr :rest, :global
   slot :inner_block
 
   def tr(assigns) do
@@ -223,7 +223,7 @@ defmodule DaisyUIComponents.Table do
 
   attr :class, :any, default: nil
   attr :collapse_breakpoint, :string, values: sizes()
-  attr :rest, :global, include: ~w(align bgcolor char charoff colspan headers height rowspan valign width)
+  attr :rest, :global, include: ~w(colspan headers rowspan)
   slot :inner_block
 
   def td(assigns) do
@@ -261,7 +261,7 @@ defmodule DaisyUIComponents.Table do
     doc: "the event name for phx-click on header columns for sorting"
 
   attr :rest, :global,
-    include: ~w(abbr align bgcolor char charoff colspan headers height rowspan scope valign width)
+    include: ~w(abbr colspan headers rowspan scope)
   slot :inner_block
 
   def th(assigns) do
@@ -298,7 +298,7 @@ defmodule DaisyUIComponents.Table do
   end
 
   attr :class, :any, default: nil
-  attr :rest, :global, include: ~w(align char charoff valign)
+  attr :rest, :global
   slot :inner_block
 
   def thead(assigns) do
@@ -310,7 +310,7 @@ defmodule DaisyUIComponents.Table do
   end
 
   attr :class, :any, default: nil
-  attr :rest, :global, include: ~w(align char charoff valign)
+  attr :rest, :global
   slot :inner_block
 
   def tbody(assigns) do

--- a/lib/daisy_ui_components/table.ex
+++ b/lib/daisy_ui_components/table.ex
@@ -95,7 +95,7 @@ defmodule DaisyUIComponents.Table do
 
   attr :zebra, :boolean, default: false
   attr :size, :string, values: sizes()
-  attr :rest, :global
+  attr :rest, :global, include: ~w(align bgcolor border cellpadding cellspacing frame rules summary width)
   slot :inner_block
 
   def table(%{rows: _rows} = assigns) do
@@ -199,7 +199,7 @@ defmodule DaisyUIComponents.Table do
   attr :class, :any, default: nil
   attr :active, :boolean, default: false
   attr :hover, :boolean, default: false
-  attr :rest, :global
+  attr :rest, :global, include: ~w(align bgcolor char charoff valign)
   slot :inner_block
 
   def tr(assigns) do
@@ -223,7 +223,7 @@ defmodule DaisyUIComponents.Table do
 
   attr :class, :any, default: nil
   attr :collapse_breakpoint, :string, values: sizes()
-  attr :rest, :global
+  attr :rest, :global, include: ~w(align bgcolor char charoff colspan headers height rowspan valign width)
   slot :inner_block
 
   def td(assigns) do
@@ -260,7 +260,8 @@ defmodule DaisyUIComponents.Table do
     default: "sort",
     doc: "the event name for phx-click on header columns for sorting"
 
-  attr :rest, :global
+  attr :rest, :global,
+    include: ~w(abbr align bgcolor char charoff colspan headers height rowspan scope valign width)
   slot :inner_block
 
   def th(assigns) do
@@ -297,7 +298,7 @@ defmodule DaisyUIComponents.Table do
   end
 
   attr :class, :any, default: nil
-  attr :rest, :global
+  attr :rest, :global, include: ~w(align char charoff valign)
   slot :inner_block
 
   def thead(assigns) do
@@ -309,7 +310,7 @@ defmodule DaisyUIComponents.Table do
   end
 
   attr :class, :any, default: nil
-  attr :rest, :global
+  attr :rest, :global, include: ~w(align char charoff valign)
   slot :inner_block
 
   def tbody(assigns) do

--- a/test/daisy_ui_components/table_test.exs
+++ b/test/daisy_ui_components/table_test.exs
@@ -135,19 +135,17 @@ defmodule DaisyUIComponents.TableTest do
     |> assert_attribute("scope", "col")
 
     ~H"""
-    <.thead class="test-thead" data-header="true" />
+    <.thead class="test-thead" />
     """
     |> parse_component()
     |> assert_component("thead")
     |> assert_class("test-thead")
-    |> assert_attribute("data-header", "true")
 
     ~H"""
-    <.tbody class="test-tbody" data-body="true" />
+    <.tbody class="test-tbody" />
     """
     |> parse_component()
     |> assert_component("tbody")
     |> assert_class("test-tbody")
-    |> assert_attribute("data-body", "true")
   end
 end

--- a/test/daisy_ui_components/table_test.exs
+++ b/test/daisy_ui_components/table_test.exs
@@ -145,7 +145,7 @@ defmodule DaisyUIComponents.TableTest do
     assigns = %{}
 
     ~H"""
-    <.table data-role="main" container_element={false}>
+    <.table container_element={false}>
       <.thead data-header="true">
         <.tr data-row="head">
           <.th abbr="id" colspan="2" headers="hdr" rowspan="1" scope="col">
@@ -164,7 +164,6 @@ defmodule DaisyUIComponents.TableTest do
     """
     |> parse_component()
     |> assert_component("table")
-    |> assert_attribute("data-role", "main")
     |> assert_children("thead", fn thead ->
       thead
       |> assert_attribute("data-header", "true")

--- a/test/daisy_ui_components/table_test.exs
+++ b/test/daisy_ui_components/table_test.exs
@@ -113,88 +113,41 @@ defmodule DaisyUIComponents.TableTest do
     assigns = %{}
 
     ~H"""
-    <.td class="test-td" />
+    <.td class="test-td" colspan="2" headers="hdr" rowspan="1" />
     """
     |> parse_component()
     |> assert_component("td")
     |> assert_class("test-td")
+    |> assert_attribute("colspan", "2")
+    |> assert_attribute("headers", "hdr")
+    |> assert_attribute("rowspan", "1")
 
     ~H"""
-    <.th class="test-th" />
+    <.th class="test-th" abbr="id" colspan="2" headers="hdr" rowspan="1" scope="col" />
     """
     |> parse_component()
     |> assert_component("th")
     |> assert_class("test-th")
+    |> assert_attribute("abbr", "id")
+    |> assert_attribute("colspan", "2")
+    |> assert_attribute("headers", "hdr")
+    |> assert_attribute("rowspan", "1")
+    |> assert_attribute("scope", "col")
 
     ~H"""
-    <.thead class="test-thead" />
+    <.thead class="test-thead" data-header="true" />
     """
     |> parse_component()
     |> assert_component("thead")
     |> assert_class("test-thead")
+    |> assert_attribute("data-header", "true")
 
     ~H"""
-    <.tbody class="test-tbody" />
+    <.tbody class="test-tbody" data-body="true" />
     """
     |> parse_component()
     |> assert_component("tbody")
     |> assert_class("test-tbody")
-  end
-
-  test "forwards allowed native table attributes via :rest" do
-    assigns = %{}
-
-    ~H"""
-    <.table container_element={false}>
-      <.thead data-header="true">
-        <.tr data-row="head">
-          <.th abbr="id" colspan="2" headers="hdr" rowspan="1" scope="col">
-            ID
-          </.th>
-        </.tr>
-      </.thead>
-      <.tbody data-body="true">
-        <.tr data-row="body">
-          <.td colspan="2" headers="hdr" rowspan="1">
-            123
-          </.td>
-        </.tr>
-      </.tbody>
-    </.table>
-    """
-    |> parse_component()
-    |> assert_component("table")
-    |> assert_children("thead", fn thead ->
-      thead
-      |> assert_attribute("data-header", "true")
-      |> assert_children("tr", fn tr ->
-        tr
-        |> assert_attribute("data-row", "head")
-        |> assert_children("th", fn th ->
-          th
-          |> assert_attribute("abbr", "id")
-          |> assert_attribute("colspan", "2")
-          |> assert_attribute("headers", "hdr")
-          |> assert_attribute("rowspan", "1")
-          |> assert_attribute("scope", "col")
-          |> assert_text("ID")
-        end)
-      end)
-    end)
-    |> assert_children("tbody", fn tbody ->
-      tbody
-      |> assert_attribute("data-body", "true")
-      |> assert_children("tr", fn tr ->
-        tr
-        |> assert_attribute("data-row", "body")
-        |> assert_children("td", fn td ->
-          td
-          |> assert_attribute("colspan", "2")
-          |> assert_attribute("headers", "hdr")
-          |> assert_attribute("rowspan", "1")
-          |> assert_text("123")
-        end)
-      end)
-    end)
+    |> assert_attribute("data-body", "true")
   end
 end

--- a/test/daisy_ui_components/table_test.exs
+++ b/test/daisy_ui_components/table_test.exs
@@ -141,40 +141,21 @@ defmodule DaisyUIComponents.TableTest do
     |> assert_class("test-tbody")
   end
 
-  test "forwards native table attributes via :rest" do
+  test "forwards allowed native table attributes via :rest" do
     assigns = %{}
 
     ~H"""
-    <.table
-      align="center"
-      border="1"
-      cellpadding="2"
-      cellspacing="3"
-      frame="box"
-      rules="all"
-      summary="Example summary"
-      width="100%"
-      container_element={false}
-    >
-      <.thead align="left" char="-" charoff="1" valign="middle">
-        <.tr align="right" bgcolor="#eee" char="." charoff="2" valign="top">
-          <.th
-            abbr="id"
-            colspan="2"
-            headers="hdr"
-            height="10"
-            rowspan="1"
-            scope="col"
-            valign="bottom"
-            width="50"
-          >
+    <.table data-role="main" container_element={false}>
+      <.thead data-header="true">
+        <.tr data-row="head">
+          <.th abbr="id" colspan="2" headers="hdr" rowspan="1" scope="col">
             ID
           </.th>
         </.tr>
       </.thead>
-      <.tbody align="left" char="-" charoff="3" valign="middle">
-        <.tr align="left" bgcolor="#fafafa" char="/" charoff="4" valign="bottom">
-          <.td colspan="2" headers="hdr" height="20" rowspan="1" valign="middle" width="60">
+      <.tbody data-body="true">
+        <.tr data-row="body">
+          <.td colspan="2" headers="hdr" rowspan="1">
             123
           </.td>
         </.tr>
@@ -183,62 +164,35 @@ defmodule DaisyUIComponents.TableTest do
     """
     |> parse_component()
     |> assert_component("table")
-    |> assert_attribute("align", "center")
-    |> assert_attribute("border", "1")
-    |> assert_attribute("cellpadding", "2")
-    |> assert_attribute("cellspacing", "3")
-    |> assert_attribute("frame", "box")
-    |> assert_attribute("rules", "all")
-    |> assert_attribute("summary", "Example summary")
-    |> assert_attribute("width", "100%")
+    |> assert_attribute("data-role", "main")
     |> assert_children("thead", fn thead ->
       thead
-      |> assert_attribute("align", "left")
-      |> assert_attribute("char", "-")
-      |> assert_attribute("charoff", "1")
-      |> assert_attribute("valign", "middle")
+      |> assert_attribute("data-header", "true")
       |> assert_children("tr", fn tr ->
         tr
-        |> assert_attribute("align", "right")
-        |> assert_attribute("bgcolor", "#eee")
-        |> assert_attribute("char", ".")
-        |> assert_attribute("charoff", "2")
-        |> assert_attribute("valign", "top")
+        |> assert_attribute("data-row", "head")
         |> assert_children("th", fn th ->
           th
           |> assert_attribute("abbr", "id")
           |> assert_attribute("colspan", "2")
           |> assert_attribute("headers", "hdr")
-          |> assert_attribute("height", "10")
           |> assert_attribute("rowspan", "1")
           |> assert_attribute("scope", "col")
-          |> assert_attribute("valign", "bottom")
-          |> assert_attribute("width", "50")
           |> assert_text("ID")
         end)
       end)
     end)
     |> assert_children("tbody", fn tbody ->
       tbody
-      |> assert_attribute("align", "left")
-      |> assert_attribute("char", "-")
-      |> assert_attribute("charoff", "3")
-      |> assert_attribute("valign", "middle")
+      |> assert_attribute("data-body", "true")
       |> assert_children("tr", fn tr ->
         tr
-        |> assert_attribute("align", "left")
-        |> assert_attribute("bgcolor", "#fafafa")
-        |> assert_attribute("char", "/")
-        |> assert_attribute("charoff", "4")
-        |> assert_attribute("valign", "bottom")
+        |> assert_attribute("data-row", "body")
         |> assert_children("td", fn td ->
           td
           |> assert_attribute("colspan", "2")
           |> assert_attribute("headers", "hdr")
-          |> assert_attribute("height", "20")
           |> assert_attribute("rowspan", "1")
-          |> assert_attribute("valign", "middle")
-          |> assert_attribute("width", "60")
           |> assert_text("123")
         end)
       end)

--- a/test/daisy_ui_components/table_test.exs
+++ b/test/daisy_ui_components/table_test.exs
@@ -140,4 +140,108 @@ defmodule DaisyUIComponents.TableTest do
     |> assert_component("tbody")
     |> assert_class("test-tbody")
   end
+
+  test "forwards native table attributes via :rest" do
+    assigns = %{}
+
+    ~H"""
+    <.table
+      align="center"
+      border="1"
+      cellpadding="2"
+      cellspacing="3"
+      frame="box"
+      rules="all"
+      summary="Example summary"
+      width="100%"
+      container_element={false}
+    >
+      <.thead align="left" char="-" charoff="1" valign="middle">
+        <.tr align="right" bgcolor="#eee" char="." charoff="2" valign="top">
+          <.th
+            abbr="id"
+            colspan="2"
+            headers="hdr"
+            height="10"
+            rowspan="1"
+            scope="col"
+            valign="bottom"
+            width="50"
+          >
+            ID
+          </.th>
+        </.tr>
+      </.thead>
+      <.tbody align="left" char="-" charoff="3" valign="middle">
+        <.tr align="left" bgcolor="#fafafa" char="/" charoff="4" valign="bottom">
+          <.td colspan="2" headers="hdr" height="20" rowspan="1" valign="middle" width="60">
+            123
+          </.td>
+        </.tr>
+      </.tbody>
+    </.table>
+    """
+    |> parse_component()
+    |> assert_component("table")
+    |> assert_attribute("align", "center")
+    |> assert_attribute("border", "1")
+    |> assert_attribute("cellpadding", "2")
+    |> assert_attribute("cellspacing", "3")
+    |> assert_attribute("frame", "box")
+    |> assert_attribute("rules", "all")
+    |> assert_attribute("summary", "Example summary")
+    |> assert_attribute("width", "100%")
+    |> assert_children("thead", fn thead ->
+      thead
+      |> assert_attribute("align", "left")
+      |> assert_attribute("char", "-")
+      |> assert_attribute("charoff", "1")
+      |> assert_attribute("valign", "middle")
+      |> assert_children("tr", fn tr ->
+        tr
+        |> assert_attribute("align", "right")
+        |> assert_attribute("bgcolor", "#eee")
+        |> assert_attribute("char", ".")
+        |> assert_attribute("charoff", "2")
+        |> assert_attribute("valign", "top")
+        |> assert_children("th", fn th ->
+          th
+          |> assert_attribute("abbr", "id")
+          |> assert_attribute("colspan", "2")
+          |> assert_attribute("headers", "hdr")
+          |> assert_attribute("height", "10")
+          |> assert_attribute("rowspan", "1")
+          |> assert_attribute("scope", "col")
+          |> assert_attribute("valign", "bottom")
+          |> assert_attribute("width", "50")
+          |> assert_text("ID")
+        end)
+      end)
+    end)
+    |> assert_children("tbody", fn tbody ->
+      tbody
+      |> assert_attribute("align", "left")
+      |> assert_attribute("char", "-")
+      |> assert_attribute("charoff", "3")
+      |> assert_attribute("valign", "middle")
+      |> assert_children("tr", fn tr ->
+        tr
+        |> assert_attribute("align", "left")
+        |> assert_attribute("bgcolor", "#fafafa")
+        |> assert_attribute("char", "/")
+        |> assert_attribute("charoff", "4")
+        |> assert_attribute("valign", "bottom")
+        |> assert_children("td", fn td ->
+          td
+          |> assert_attribute("colspan", "2")
+          |> assert_attribute("headers", "hdr")
+          |> assert_attribute("height", "20")
+          |> assert_attribute("rowspan", "1")
+          |> assert_attribute("valign", "middle")
+          |> assert_attribute("width", "60")
+          |> assert_text("123")
+        end)
+      end)
+    end)
+  end
 end


### PR DESCRIPTION
This pull request enhances the flexibility of the `td` and `th` components in the `DaisyUIComponents.Table` module by allowing additional standard HTML table attributes to be passed through. It also updates the related tests to verify the correct handling of these new attributes.

**Component enhancements:**

* Updated the `td` component to accept `colspan`, `headers`, and `rowspan` as additional HTML attributes via the `:rest` option.
* Updated the `th` component to accept `abbr`, `colspan`, `headers`, `rowspan`, and `scope` as additional HTML attributes via the `:rest` option.

**Test updates:**

* Extended tests in `DaisyUIComponents.TableTest` to ensure that the new attributes (`abbr`, `colspan`, `headers`, `rowspan`, `scope`) are correctly passed through and rendered on the `td` and `th` components.