### PR TITLE
Ignore `open` attribute on modal dialog

### DIFF
--- a/installer/templates/components/modal.ex
+++ b/installer/templates/components/modal.ex
@@ -65,7 +65,10 @@ defmodule <%= if not @dev do @web_namespace <> "." end %>DaisyUIComponents.Modal
     <dialog
       id={@id}
       class={["modal", @class]}
-      phx-mounted={@open && show_modal(@id)}
+      phx-mounted={
+        js = JS.ignore_attributes("open")
+        if @open, do: show_modal(js, @id), else: js
+      }
       phx-remove={hide_modal(@id)}
       data-cancel={JS.exec(@on_cancel, "phx-remove")}
       {@rest}

--- a/lib/daisy_ui_components/modal.ex
+++ b/lib/daisy_ui_components/modal.ex
@@ -65,7 +65,10 @@ defmodule DaisyUIComponents.Modal do
     <dialog
       id={@id}
       class={["modal", @class]}
-      phx-mounted={@open && show_modal(@id)}
+      phx-mounted={
+        js = JS.ignore_attributes("open")
+        if @open, do: show_modal(js, @id), else: js
+      }
       phx-remove={hide_modal(@id)}
       data-cancel={JS.exec(@on_cancel, "phx-remove")}
       {@rest}

--- a/test/daisy_ui_components/modal_test.exs
+++ b/test/daisy_ui_components/modal_test.exs
@@ -1,9 +1,11 @@
 defmodule DaisyUIComponents.ModalTest do
-  use ExUnit.Case
+  use DaisyUIComponents.ComponentCase
 
   import Phoenix.Component
   import Phoenix.LiveViewTest
   import DaisyUIComponents.Modal
+
+  alias Phoenix.LiveView.JS
 
   describe "modal" do
     test "simple dialog modal" do
@@ -50,6 +52,47 @@ defmodule DaisyUIComponents.ModalTest do
       assert modal =~ ~s(Action from component)
       assert modal =~ ~s(First Action)
       assert modal =~ ~s(Second Action)
+    end
+
+    test "closed modal only ignores the open attribute" do
+      assigns = %{}
+
+      assert ~H"""
+             <.modal id="confirm">
+               my dialog modal
+             </.modal>
+             """
+             |> parse_component()
+             |> assert_component("dialog")
+             |> attribute("phx-mounted") == Jason.encode!(JS.ignore_attributes("open"))
+    end
+
+    test "open modal ignores the open attribute before showing" do
+      assigns = %{}
+
+      assert ~H"""
+             <.modal id="confirm" open>
+               my dialog modal
+             </.modal>
+             """
+             |> parse_component()
+             |> assert_component("dialog")
+             |> attribute("phx-mounted") ==
+               Jason.encode!(show_modal(JS.ignore_attributes("open"), "confirm"))
+    end
+
+    test "shown modal ignores the open attribute before showing" do
+      assigns = %{}
+
+      assert ~H"""
+             <.modal id="confirm" show>
+               my dialog modal
+             </.modal>
+             """
+             |> parse_component()
+             |> assert_component("dialog")
+             |> attribute("phx-mounted") ==
+               Jason.encode!(show_modal(JS.ignore_attributes("open"), "confirm"))
     end
   end
 end


### PR DESCRIPTION
[Ignores](https://phoenix-live-view.hexdocs.pm/Phoenix.LiveView.JS.html#ignore_attributes/1) the patching of the `open` attribute by LiveView of the `dialog` element when mounting it in the page, so the modal component keeps it opened state between LiveView updates.